### PR TITLE
ccronexpr_test: zero time structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Compilation and tests run examples
 ----------------------------------
 
     gcc ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c89 -DCRON_TEST_MALLOC -o a.out && ./a.out
-    gcc -DCRON_USE_LOCAL_TIME ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c89 -DCRON_TEST_MALLOC -o a.out && ./a.out
+    gcc -DCRON_USE_LOCAL_TIME ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c89 -DCRON_TEST_MALLOC -o a.out && TZ="America/Toronto" ./a.out
     g++ ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c++11 -DCRON_TEST_MALLOC -o a.out && ./a.out
     g++ ccronexpr.c ccronexpr_test.c -I. -Wall -Wextra -std=c++11 -DCRON_TEST_MALLOC -DCRON_COMPILE_AS_CXX -o a.out && ./a.out
 

--- a/ccronexpr_test.c
+++ b/ccronexpr_test.c
@@ -174,6 +174,8 @@ int four_dec_num(const char *first) {
 /* 0123456789012345678 */
 struct tm* poors_mans_strptime(const char* str) {
     struct tm* cal = (struct tm*) malloc(sizeof(struct tm));
+    assert(cal != NULL);
+    memset(cal, 0, sizeof(struct tm));
     cal->tm_year = four_dec_num(str) - 1900;
     cal->tm_mon = two_dec_num(str + 5) - 1;
     cal->tm_mday = two_dec_num(str + 8);


### PR DESCRIPTION
Ensure the struct tm returned by the local version of strptime() doesn't
contain garbage. Fixes the test in commit 397cada8614 on 64-bit platforms.

Also set the timezone in the example in the README.

This should fix https://github.com/staticlibs/ccronexpr/pull/21#issuecomment-476870253.