### PR TITLE
Initialize passed cron_expr to zero

### DIFF
--- a/ccronexpr.c
+++ b/ccronexpr.c
@@ -890,6 +890,7 @@ void cron_parse_expr(const char* expression, cron_expr* target, const char** err
         *error = "Invalid number of fields, expression must consist of 6 fields";
         goto return_res;
     }
+    memset(target, 0, sizeof(*target));
     set_number_hits(fields[0], target->seconds, 0, 60, error);
     if (*error) goto return_res;
     set_number_hits(fields[1], target->minutes, 0, 60, error);

--- a/ccronexpr_test.c
+++ b/ccronexpr_test.c
@@ -190,7 +190,6 @@ struct tm* poors_mans_strptime(const char* str) {
 void check_next(const char* pattern, const char* initial, const char* expected) {
     const char* err = NULL;
     cron_expr parsed;
-    memset(&parsed, 0, sizeof(parsed));
     cron_parse_expr(pattern, &parsed, &err);
 
     struct tm* calinit = poors_mans_strptime(initial);
@@ -223,17 +222,14 @@ void check_next(const char* pattern, const char* initial, const char* expected) 
 
 void check_same(const char* expr1, const char* expr2) {
     cron_expr parsed1;
-    memset(&parsed1, 0, sizeof(parsed1));
     cron_parse_expr(expr1, &parsed1, NULL);
     cron_expr parsed2;
-    memset(&parsed2, 0, sizeof(parsed2));
     cron_parse_expr(expr2, &parsed2, NULL);
     assert(crons_equal(&parsed1, &parsed2));
 }
 
 void check_calc_invalid() {
     cron_expr parsed;
-    memset(&parsed, 0, sizeof(parsed));
     cron_parse_expr("0 0 0 31 6 *", &parsed, NULL);
     struct tm * calinit = poors_mans_strptime("2012-07-01_09:53:50");
     time_t dateinit = timegm(calinit);
@@ -245,7 +241,6 @@ void check_calc_invalid() {
 void check_expr_invalid(const char* expr) {
     const char* err = NULL;
     cron_expr test;
-    memset(&test, 0, sizeof(test));
     cron_parse_expr(expr, &test, &err);
     assert(err);
 }


### PR DESCRIPTION
Before this commit, if it wasn't initialized, cron_parse_expr()
returned mostly wrong results (and also tests failed).
So it should be either made clear in header file that passed
parameter must be initialized, or done inside cron_parse_expr().